### PR TITLE
socket draw debug

### DIFF
--- a/src/CursorCanvas/index.js
+++ b/src/CursorCanvas/index.js
@@ -4,16 +4,39 @@ import "./style.css";
 
 function CursorCanvas() {
   const canvas = useRef(null);
+  const pointers = useRef([]);
 
   useEffect(() => {
     socket.on("updatepointer", (data) => {
-      const ctx = canvas.current.getContext("2d");
-      drawOnCanvas(ctx, data.x, data.y, data.color); // 색상을 인자로 전달
+      updatePointers(data); 
+      redrawCanvas();
     });
-  });
+  },[]);
 
-  function drawOnCanvas(ctx, x, y, color) {
-    ctx.clearRect(0, 0, canvas.width, canvas.height); // 캔버스 클리어
+  const updatePointers = (data) => {
+    // 새로운 포인터 데이터 추가 또는 업데이트
+    const index = pointers.current.findIndex(p => p.id === data.id);
+    if (index >= 0) {
+      pointers.current[index] = data;
+    } else {
+      pointers.current.push(data);
+    }
+  };
+
+  const clearCanvas = () => {
+    const ctx = canvas.current.getContext("2d");
+    ctx.clearRect(0, 0, canvas.current.width, canvas.current.height);
+  };
+
+  const redrawCanvas = () => {
+    clearCanvas();
+    pointers.current.forEach(p => {
+      drawOnCanvas(p.x, p.y, p.color);
+    });
+  };
+
+  function drawOnCanvas(x, y, color) {
+    const ctx = canvas.current.getContext("2d");
     ctx.fillStyle = color; // 서버로부터 받은 색상 사용
     ctx.font = "20px Arial";
     ctx.fillText("여기", x, y); // 텍스트 그리기

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,7 +1,7 @@
 import { io } from "socket.io-client";
 
 // "undefined" means the URL will be computed from the `window.location` object
-export const baseURL = process.env.NODE_ENV === "production" ? window.location.origin : "http://localhost:5000";
+export const baseURL = process.env.NODE_ENV === "production" ? window.location.origin : "http://localhost:3000";
 
 const socket = io(baseURL, {
   withCredentials: true,


### PR DESCRIPTION
# 문제
* 다른 사람의 커서가 새로 들어왔을 때, 기존의 커서가 사라지는 현상
  * 즉. 커서가 하나만 표시되는 현상이 있었음
  * socket 데이터를 받을 때마다 배경을 덮어씌우고, 해당 데이터만 그리기 때문임
# 해결
* 커서가 아닌 커서'들'을 관리하기 위해서 배열을 따로 지정함
* clientid를 중심으로 배열안의 커서를 찾아서 socket에서 받은 데이터로 업데이트함

# TODO
* 소켓 연결이 끊기면, 해당 커서가 더이상 업데이트 되지 못해 화면에 고정된 채로 재연결시 커서가 새로 배정됨.
  * 즉 연결이 새로 될 때마다 커서가 화면에 박히는 현상이 발생함
* 이를 해결하기 위해 커서의 배열 정보를 각 클라이언트가 아닌, 서버가 한번에 관리하고 업데이트시 한번에 쏴주는 게 필요함.
* 이 때 매 요청시가 아닌, 일정 시간이나 일정량 모아서 전송하는 방식으로 데이터 통신 횟수를 줄이는 방법을 고려해볼 수 있을 것 같음.